### PR TITLE
ecs cleanup 1

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,13 @@
+Features:
+    MapPicker:
+        Add random map picker 
+        ☐ get list of available maps
+        
+Tooling:
+    ☐ figure out a way to make golint order imports how i want
+
+Testing:
+    ☐ fix the testdata thing it's dumb right now
+
+Improvements:
+    ☐ add CivKey.INVALID as a constant

--- a/cmd/civ-bot-go/main.go
+++ b/cmd/civ-bot-go/main.go
@@ -2,34 +2,36 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/bwmarrin/discordgo"
+
 	"github.com/ecshreve/civ-bot-go/internal/civsession"
 )
 
 func main() {
 	token := os.Getenv("CIV_BOT_TOKEN")
 
-	// Create a new Discord session using the provided bot token.
+	// Create a new Discord session using the provided bot token, if we
+	// encounter an error log it and exit.
 	dg, err := discordgo.New("Bot " + token)
 	if err != nil {
-		fmt.Println("error creating Discord session,", err)
-		return
+		log.Fatalf("error creating Discord session - %+v", err)
 	}
 
+	// Create a new CivSession, and attach handlers to the DiscordSession.
 	cs := civsession.NewCivSession()
-
 	dg.AddHandler(cs.CommandsHandler)
 	dg.AddHandler(cs.ReactionsHandler)
 
-	// Open a websocket connection to Discord and begin listening.
+	// Open a websocket connection to Discord and begin listening, if we
+	// encounter an error log it and exit.
 	err = dg.Open()
 	if err != nil {
-		fmt.Println("error opening connection,", err)
-		return
+		log.Fatalf("error opening connection - %+v", err)
 	}
 
 	// Wait here until CTRL-C or other term signal is received.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ecshreve/civ-bot-go
 go 1.12
 
 require (
+	github.com/benbjohnson/clock v1.0.2
 	github.com/bwmarrin/discordgo v0.20.3
 	github.com/kr/pretty v0.2.0
 	github.com/schollz/closestmatch v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/benbjohnson/clock v1.0.2 h1:Z0CN0Yb4ig9sGPXkvAQcGJfnrrMQ5QYLCMPRi9iD7YE=
+github.com/benbjohnson/clock v1.0.2/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/bwmarrin/discordgo v0.20.3 h1:AxjcHGbyBFSC0a3Zx5nDQwbOjU7xai5dXjRnZ0YB7nU=
 github.com/bwmarrin/discordgo v0.20.3/go.mod h1:O9S4p+ofTFwB02em7jkpkV8M3R0/PUVOwN61zSZ0r4Q=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/internal/civ/civ.go
+++ b/internal/civ/civ.go
@@ -36,10 +36,10 @@ type Civ struct {
 // defined in the constants package.
 func GenCivs() []*Civ {
 	civs := make([]*Civ, 0)
-	for k, c := range constants.CivBase {
+	for _, k := range constants.CivKeys {
 		civ := &Civ{
 			Key:        k,
-			CivBase:    c,
+			CivBase:    constants.CivBase[k],
 			LeaderBase: constants.CivLeaders[k],
 			ZigURL:     constants.CivZig[k],
 			FilthyTier: constants.CivFilthyTiers[k],

--- a/internal/civ/civ.go
+++ b/internal/civ/civ.go
@@ -51,10 +51,12 @@ func GenCivs() []*Civ {
 
 // GenCivMap generates and returns a map of CivKey to Civ for all base values
 // defined in the constants package.
-func GenCivMap() map[constants.CivKey]*Civ {
-	civs := GenCivs()
-	civMap := make(map[constants.CivKey]*Civ)
+func GenCivMap(civs []*Civ) map[constants.CivKey]*Civ {
+	if len(civs) == 0 {
+		return nil
+	}
 
+	civMap := make(map[constants.CivKey]*Civ)
 	for _, c := range civs {
 		civMap[c.Key] = c
 	}

--- a/internal/civ/civ.go
+++ b/internal/civ/civ.go
@@ -3,23 +3,37 @@ package civ
 import (
 	"fmt"
 
-	"github.com/ecshreve/civ-bot-go/internal/constants"
 	"github.com/schollz/closestmatch"
+
+	"github.com/ecshreve/civ-bot-go/internal/constants"
 )
 
 // Civ represents an individual civilization.
 type Civ struct {
-	Key        constants.CivKey
-	CivBase    string
+	// Key is the CivKey enum entry for this Civ.
+	Key constants.CivKey
+
+	// CivBase is the string representation of the Civ's name.
+	CivBase string
+
+	// LeaderBase is the string representation of the Civ's Leader's name.
 	LeaderBase string
-	ZigURL     string
+
+	// ZigURL is the URL of the ZigZagal guide for the Civ.
+	ZigURL string
+
+	// FilthyTier is an integer [1...6] representing the Civ's tier.
 	FilthyTier int
-	Banned     bool
-	Picked     bool
+
+	// Banned is a boolean indicating if this Civ is currently banned.
+	Banned bool
+
+	// Picked is a boolean indicating if this Civ has been picked for a Player.
+	Picked bool
 }
 
-// GenCivs generates and returns a slice of Civs based on the base values in the
-// constants file.
+// GenCivs generates and returns a slice of Civs for all the base values
+// defined in the constants package.
 func GenCivs() []*Civ {
 	civs := make([]*Civ, 0)
 	for k, c := range constants.CivBase {
@@ -35,9 +49,23 @@ func GenCivs() []*Civ {
 	return civs
 }
 
+// GenCivMap generates and returns a map of CivKey to Civ for all base values
+// defined in the constants package.
+func GenCivMap() map[constants.CivKey]*Civ {
+	civs := GenCivs()
+	civMap := make(map[constants.CivKey]*Civ)
+
+	for _, c := range civs {
+		civMap[c.Key] = c
+	}
+
+	return civMap
+}
+
 // GetCivByString takes a string and returns the Civ whose name or leader most
 // closely matches the input string.
 func GetCivByString(s string, civs []*Civ) *Civ {
+	// We want to test the input string agains all civiliation and leader names.
 	strsToTest := make([]string, 0)
 	for _, k := range constants.CivKeys {
 		strsToTest = append(strsToTest, constants.CivBase[k])
@@ -50,15 +78,12 @@ func GetCivByString(s string, civs []*Civ) *Civ {
 
 	retCiv := &Civ{}
 	for _, c := range civs {
-		if c.CivBase == closest {
-			retCiv = c
-			break
-		}
-		if c.LeaderBase == closest {
+		if c.CivBase == closest || c.LeaderBase == closest {
 			retCiv = c
 			break
 		}
 	}
+
 	return retCiv
 }
 

--- a/internal/civ/civ_test.go
+++ b/internal/civ/civ_test.go
@@ -3,15 +3,16 @@ package civ_test
 import (
 	"testing"
 
-	"github.com/ecshreve/civ-bot-go/internal/civ"
-	"github.com/ecshreve/civ-bot-go/internal/constants"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ecshreve/civ-bot-go/internal/civ"
+	"github.com/ecshreve/civ-bot-go/internal/constants"
 )
 
 func TestGetCivByString(t *testing.T) {
 	civs := civ.GenCivs()
+	civMap := civ.GenCivMap()
 
 	testcases := []struct {
 		desc     string
@@ -72,12 +73,7 @@ func TestGetCivByString(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.desc, func(t *testing.T) {
-			var expectedCiv *civ.Civ
-			for _, c := range civs {
-				if c.Key == testcase.expected {
-					expectedCiv = c
-				}
-			}
+			expectedCiv := civMap[testcase.expected]
 			require.NotNil(t, expectedCiv)
 
 			actualCiv := civ.GetCivByString(testcase.inp, civs)

--- a/internal/civ/civ_test.go
+++ b/internal/civ/civ_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetCivByString(t *testing.T) {
 	civs := civ.GenCivs()
-	civMap := civ.GenCivMap()
+	civMap := civ.GenCivMap(civs)
 
 	testcases := []struct {
 		desc     string
@@ -79,5 +79,16 @@ func TestGetCivByString(t *testing.T) {
 			actualCiv := civ.GetCivByString(testcase.inp, civs)
 			assert.Equal(t, expectedCiv, actualCiv)
 		})
+	}
+}
+
+func TestGenCivMap(t *testing.T) {
+	civs := civ.GenCivs()
+	civMap := civ.GenCivMap(civs)
+
+	// Make sure that the values in our CivMap point to the same Civs as the
+	// items in the slice passed in to GenCivMap.
+	for _, c := range civs {
+		assert.Same(t, c, civMap[c.Key])
 	}
 }

--- a/internal/civsession/actions.go
+++ b/internal/civsession/actions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+
 	"github.com/ecshreve/civ-bot-go/internal/civ"
 	"github.com/ecshreve/civ-bot-go/internal/constants"
 )
@@ -14,6 +15,12 @@ import (
 // banCiv does a fuzzy match on the given string, if it finds a match it sets that
 // Civ's Banned value to true and updates the CivSession's slice of Bans.
 func (cs *CivSession) banCiv(civToBan string, userID string) *civ.Civ {
+	if civToBan == "" || userID == "" {
+		return nil
+	}
+
+	// If we didn't find a match, or the matched Civ is already banned then just
+	// return nil.
 	c := civ.GetCivByString(civToBan, cs.Civs)
 	if c == nil || c.Banned == true {
 		return nil
@@ -26,18 +33,23 @@ func (cs *CivSession) banCiv(civToBan string, userID string) *civ.Civ {
 		cs.Bans[userID] = cs.Bans[userID][1:]
 	}
 
-	// Add this Civ to the ban list.
+	// Add this Civ to the CivSession's slice of Bans.
 	c.Banned = true
 	cs.Bans[userID] = append(cs.Bans[userID], c)
 
 	return c
 }
 
+// makePick returns a random Civ from the given slice of Civs that has not been
+// marked as Picked.
 func makePick(civs []*civ.Civ) *civ.Civ {
 	rand.Seed(time.Now().Unix())
 
 	var p *civ.Civ
 	foundPick := false
+
+	// Keep picking at random until we find a Civ that hasn't been picked yet.
+	// Once we find one, mark it as picked.
 	for !foundPick {
 		n := rand.Int() % len(civs)
 		p = civs[n]
@@ -45,8 +57,8 @@ func makePick(civs []*civ.Civ) *civ.Civ {
 			foundPick = true
 		}
 	}
-
 	p.Picked = true
+
 	return p
 }
 

--- a/internal/civsession/actions_internal_test.go
+++ b/internal/civsession/actions_internal_test.go
@@ -1,0 +1,79 @@
+package civsession
+
+import (
+	"testing"
+
+	"github.com/ecshreve/civ-bot-go/internal/constants"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/ecshreve/civ-bot-go/internal/civ"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBanCiv(t *testing.T) {
+	testdata := NewTestData()
+	players := testdata.Players
+	playerMap := make(map[string]*discordgo.User)
+	for _, p := range players {
+		playerMap[p.ID] = p
+	}
+	civMap := civ.GenCivMap()
+
+	testcases := []struct {
+		description string
+		civToBan    string
+		expected    *civ.Civ
+	}{
+		{
+			description: "empty string expect nil",
+			civToBan:    "",
+			expected:    nil,
+		},
+		{
+			description: "ban by civ name",
+			civToBan:    "america",
+			expected:    civMap[constants.AMERICA],
+		},
+		{
+			description: "ban by leader name",
+			civToBan:    "washington",
+			expected:    civMap[constants.AMERICA],
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.description, func(t *testing.T) {
+			cs := NewCivSession()
+			cs.Players = playerMap
+			testPlayer := players[0]
+
+			actual := cs.banCiv(testcase.civToBan, testPlayer.ID)
+			if testcase.expected != nil {
+				// Make sure we only banned the expected Civ and all others are
+				// not banned.
+				for _, c := range cs.Civs {
+					if c.Key == testcase.expected.Key {
+						assert.True(t, c.Banned)
+					} else {
+						assert.False(t, c.Banned)
+					}
+				}
+
+				// Make sure our expected Civ is the only item in the CivSession
+				// Ban slice.
+				assert.Equal(t, 1, len(cs.Bans))
+				foundInBans := false
+				for _, c := range cs.Bans[testPlayer.ID] {
+					if c.Key == testcase.expected.Key {
+						foundInBans = true
+						break
+					}
+				}
+				assert.True(t, foundInBans)
+			} else {
+				assert.Nil(t, actual)
+			}
+		})
+	}
+}

--- a/internal/civsession/actions_internal_test.go
+++ b/internal/civsession/actions_internal_test.go
@@ -3,12 +3,10 @@ package civsession
 import (
 	"testing"
 
-	"github.com/ecshreve/civ-bot-go/internal/constants"
-
 	"github.com/bwmarrin/discordgo"
-	"github.com/ecshreve/civ-bot-go/internal/civ"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ecshreve/civ-bot-go/internal/constants"
 )
 
 func TestBanCiv(t *testing.T) {
@@ -18,27 +16,29 @@ func TestBanCiv(t *testing.T) {
 	for _, p := range players {
 		playerMap[p.ID] = p
 	}
-	civMap := civ.GenCivMap()
 
 	testcases := []struct {
 		description string
 		civToBan    string
-		expected    *civ.Civ
+		expectBan   bool
+		expected    constants.CivKey
 	}{
 		{
 			description: "empty string expect nil",
 			civToBan:    "",
-			expected:    nil,
+			expectBan:   false,
 		},
 		{
 			description: "ban by civ name",
 			civToBan:    "america",
-			expected:    civMap[constants.AMERICA],
+			expectBan:   true,
+			expected:    constants.AMERICA,
 		},
 		{
 			description: "ban by leader name",
 			civToBan:    "washington",
-			expected:    civMap[constants.AMERICA],
+			expectBan:   true,
+			expected:    constants.AMERICA,
 		},
 	}
 
@@ -47,13 +47,14 @@ func TestBanCiv(t *testing.T) {
 			cs := NewCivSession()
 			cs.Players = playerMap
 			testPlayer := players[0]
+			expectedCiv := cs.CivMap[testcase.expected]
 
 			actual := cs.banCiv(testcase.civToBan, testPlayer.ID)
-			if testcase.expected != nil {
+			if testcase.expectBan {
 				// Make sure we only banned the expected Civ and all others are
 				// not banned.
 				for _, c := range cs.Civs {
-					if c.Key == testcase.expected.Key {
+					if c.Key == expectedCiv.Key {
 						assert.True(t, c.Banned)
 					} else {
 						assert.False(t, c.Banned)
@@ -65,7 +66,7 @@ func TestBanCiv(t *testing.T) {
 				assert.Equal(t, 1, len(cs.Bans))
 				foundInBans := false
 				for _, c := range cs.Bans[testPlayer.ID] {
-					if c.Key == testcase.expected.Key {
+					if c.Key == expectedCiv.Key {
 						foundInBans = true
 						break
 					}

--- a/internal/civsession/civsession.go
+++ b/internal/civsession/civsession.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/ecshreve/civ-bot-go/internal/constants"
-
 	"github.com/bwmarrin/discordgo"
+
 	"github.com/ecshreve/civ-bot-go/internal/civ"
+	"github.com/ecshreve/civ-bot-go/internal/constants"
 )
 
 // CivConfig holds a config for a CivSession.
@@ -25,6 +25,7 @@ type CivSession struct {
 	Clock            clock.Clock
 	Players          map[string]*discordgo.User
 	Civs             []*civ.Civ
+	CivMap           map[constants.CivKey]*civ.Civ
 	Bans             map[string][]*civ.Civ
 	Picks            map[string][]*civ.Civ
 	PickTime         time.Time
@@ -42,11 +43,15 @@ func NewCivSession() *CivSession {
 		UseFilthyTiers: false,
 	}
 
+	civs := civ.GenCivs()
+	civMap := civ.GenCivMap(civs)
+
 	return &CivSession{
 		Config:           cfg,
 		Clock:            clock.New(),
 		Players:          make(map[string]*discordgo.User),
-		Civs:             civ.GenCivs(),
+		Civs:             civs,
+		CivMap:           civMap,
 		Bans:             make(map[string][]*civ.Civ),
 		Picks:            make(map[string][]*civ.Civ),
 		RePicksRemaining: cfg.NumRepicks,
@@ -55,8 +60,12 @@ func NewCivSession() *CivSession {
 
 // Reset clears the CivSession referenced by the pointer receiver to the func.
 func (cs *CivSession) Reset() {
+	civs := civ.GenCivs()
+	civMap := civ.GenCivMap(civs)
+
 	cs.Players = make(map[string]*discordgo.User)
-	cs.Civs = civ.GenCivs()
+	cs.Civs = civs
+	cs.CivMap = civMap
 	cs.Bans = make(map[string][]*civ.Civ)
 	cs.Picks = make(map[string][]*civ.Civ)
 	cs.PickTime = time.Time{}

--- a/internal/civsession/civsession.go
+++ b/internal/civsession/civsession.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/ecshreve/civ-bot-go/internal/constants"
 
 	"github.com/bwmarrin/discordgo"
@@ -21,6 +22,7 @@ type CivConfig struct {
 // CivSession holds data for a single civ-bot session.
 type CivSession struct {
 	Config           *CivConfig
+	Clock            clock.Clock
 	Players          map[string]*discordgo.User
 	Civs             []*civ.Civ
 	Bans             map[string][]*civ.Civ
@@ -42,6 +44,7 @@ func NewCivSession() *CivSession {
 
 	return &CivSession{
 		Config:           cfg,
+		Clock:            clock.New(),
 		Players:          make(map[string]*discordgo.User),
 		Civs:             civ.GenCivs(),
 		Bans:             make(map[string][]*civ.Civ),


### PR DESCRIPTION
general cleanup
- manually reorder imports
- add doc comments
- add tests
- refactor some functions

validated by testing locally with civbot-test bot